### PR TITLE
[bugfix] 프로빌더로 생성한 맵에서 플레이어가 점프가 안되는 버그

### DIFF
--- a/Assets/Arts/Prefabs/Junseo's Prefab/Npc/Base Npc.prefab
+++ b/Assets/Arts/Prefabs/Junseo's Prefab/Npc/Base Npc.prefab
@@ -3265,6 +3265,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: aa6e789e3ed2fb841839ac26a628eea7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  hasVisitedStore: 0
 --- !u!65 &7671640666551700399
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -3280,7 +3281,7 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3

--- a/Assets/Arts/Prefabs/Player.prefab
+++ b/Assets/Arts/Prefabs/Player.prefab
@@ -109,7 +109,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 8616685848737228371, guid: c5efc39a8aaf6e64ea40e9ad573e9b47, type: 3}
       propertyPath: GroundLayers.m_Bits
-      value: 1
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 8616685848737228372, guid: c5efc39a8aaf6e64ea40e9ad573e9b47, type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
초록색 바닥에선 점프가 되는데 검은색 바닥에선 점프가 안되는 버그 발생
<- 플레이어 오브젝트에서 [Player] - [PlayerCapsule] - [Inspector] - [First Person Controller] - [Player Grounded] - [Ground Layers]에 Pass, Box 레이어 추가 하니까 해결
-----------------------------------
+ 추가로 NPC들이 Player에 부딪히는 현상 콜라이더를 IsTrigger로 바꿔서 해결